### PR TITLE
wordpress apache config

### DIFF
--- a/wordpress-configuration/apache-conf/wordpress.conf
+++ b/wordpress-configuration/apache-conf/wordpress.conf
@@ -1,0 +1,13 @@
+<VirtualHost *:80>
+	DocumentRoot /srv/www/wordpress
+	<Directory /srv/www/wordpress>
+		Options FollowSymLinks
+		AllowOverride Limit Options FileInfo
+		DirectoryIndex index.php
+		Require all granted
+	</Directory>
+	<Directory /srv/www/wordpress/wp-content>
+		Options FollowSymLinks
+		Require all granted
+	</Directory>
+</VirtualHost>


### PR DESCRIPTION
Vanilla Apache configuration. This is for git cloning and applying the configs automatically in bash scripts. 
More configuration files to come.